### PR TITLE
support for Prism custom providers

### DIFF
--- a/src/Agents/BaseLlmAgent.php
+++ b/src/Agents/BaseLlmAgent.php
@@ -138,8 +138,18 @@ abstract class BaseLlmAgent extends BaseAgent
     {
         if ($this->provider === null) {
             $defaultProvider = config('vizra-adk.default_provider', 'openai');
-            $this->provider = Provider::tryFrom($defaultProvider)?->value
-                ?? $this->resolveCustomProvider($defaultProvider);
+            $this->provider = match ($defaultProvider) {
+                'openai' => Provider::OpenAI,
+                'anthropic' => Provider::Anthropic,
+                'gemini', 'google' => Provider::Gemini,
+                'deepseek' => Provider::DeepSeek,
+                'ollama' => Provider::Ollama,
+                'mistral' => Provider::Mistral,
+                'groq' => Provider::Groq,
+                'xai', 'grok' => Provider::XAI,
+                'voyageai', 'voyage' => Provider::VoyageAI,
+                default => $this->resolveCustomProvider($defaultProvider),
+            };
         }
 
         return $this->provider;
@@ -292,7 +302,22 @@ abstract class BaseLlmAgent extends BaseAgent
      */
     public function setProvider(Provider|string $provider): static
     {
-        $this->provider = is_string($provider) ? $this->resolveCustomProvider($provider) : $provider->value;
+        if (is_string($provider)) {
+            $provider = match (strtolower($provider)) {
+                'openai' => Provider::OpenAI,
+                'anthropic' => Provider::Anthropic,
+                'gemini', 'google' => Provider::Gemini,
+                'deepseek' => Provider::DeepSeek,
+                'ollama' => Provider::Ollama,
+                'mistral' => Provider::Mistral,
+                'groq' => Provider::Groq,
+                'xai', 'grok' => Provider::XAI,
+                'voyageai', 'voyage' => Provider::VoyageAI,
+                default => $this->resolveCustomProvider($provider)
+            };
+        }
+
+        $this->provider = $provider;
 
         return $this;
     }

--- a/src/Agents/BaseLlmAgent.php
+++ b/src/Agents/BaseLlmAgent.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Event;
 use Prism\Prism\Enums\Provider;
 use Prism\Prism\Facades\Tool;
 use Prism\Prism\Prism;
+use Prism\Prism\PrismManager;
 use Prism\Prism\Schema\StringSchema;
 use Prism\Prism\Text\Response;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
@@ -53,7 +54,7 @@ abstract class BaseLlmAgent extends BaseAgent
 
     protected string $model = '';
 
-    protected ?Provider $provider = null;
+    protected ?string $provider = null;
 
     protected ?float $temperature = null;
 
@@ -133,25 +134,20 @@ abstract class BaseLlmAgent extends BaseAgent
         $this->loadSubAgents();
     }
 
-    protected function getProvider(): Provider
+    protected function getProvider(): string
     {
         if ($this->provider === null) {
             $defaultProvider = config('vizra-adk.default_provider', 'openai');
-            $this->provider = match ($defaultProvider) {
-                'openai' => Provider::OpenAI,
-                'anthropic' => Provider::Anthropic,
-                'gemini', 'google' => Provider::Gemini,
-                'deepseek' => Provider::DeepSeek,
-                'ollama' => Provider::Ollama,
-                'mistral' => Provider::Mistral,
-                'groq' => Provider::Groq,
-                'xai', 'grok' => Provider::XAI,
-                'voyageai', 'voyage' => Provider::VoyageAI,
-                default => Provider::OpenAI,
-            };
+            $this->provider = Provider::tryFrom($defaultProvider)?->value
+                ?? $this->resolveCustomProvider($defaultProvider);
         }
 
         return $this->provider;
+    }
+
+    protected function resolveCustomProvider(string $provider): string
+    {
+        return tap($provider, fn(string $provider) => resolve(PrismManager::class)->resolve($provider));
     }
 
     public function getModel(): string
@@ -161,23 +157,23 @@ abstract class BaseLlmAgent extends BaseAgent
         // Auto-detect provider based on model name if not explicitly set
         if ($this->provider === null) {
             if (str_contains($model, 'gemini') || str_contains($model, 'flash')) {
-                $this->provider = Provider::Gemini;
+                $this->provider = Provider::Gemini->value;
             } elseif (str_contains($model, 'claude')) {
-                $this->provider = Provider::Anthropic;
+                $this->provider = Provider::Anthropic->value;
             } elseif (str_contains($model, 'gpt') || str_contains($model, 'o1')) {
-                $this->provider = Provider::OpenAI;
+                $this->provider = Provider::OpenAI->value;
             } elseif (str_contains($model, 'deepseek')) {
-                $this->provider = Provider::DeepSeek;
+                $this->provider = Provider::DeepSeek->value;
             } elseif (str_contains($model, 'mistral') || str_contains($model, 'mixtral')) {
-                $this->provider = Provider::Mistral;
+                $this->provider = Provider::Mistral->value;
             } elseif (str_contains($model, 'llama') || str_contains($model, 'codellama') || str_contains($model, 'phi')) {
-                $this->provider = Provider::Ollama;
+                $this->provider = Provider::Ollama->value;
             } elseif (str_contains($model, 'groq')) {
-                $this->provider = Provider::Groq;
+                $this->provider = Provider::Groq->value;
             } elseif (str_contains($model, 'grok')) {
-                $this->provider = Provider::XAI;
+                $this->provider = Provider::XAI->value;
             } elseif (str_contains($model, 'voyage')) {
-                $this->provider = Provider::VoyageAI;
+                $this->provider = Provider::VoyageAI->value;
             }
         }
 
@@ -292,26 +288,11 @@ abstract class BaseLlmAgent extends BaseAgent
      * Set the provider for this agent.
      * Supports all Prism providers: OpenAI, Anthropic, Gemini, DeepSeek, Ollama, Mistral, Groq, XAI, VoyageAI
      *
-     * @param  Provider|string  $provider  The provider enum or string name
+     * @param Provider|string  $provider  The provider enum or string name
      */
     public function setProvider(Provider|string $provider): static
     {
-        if (is_string($provider)) {
-            $provider = match (strtolower($provider)) {
-                'openai' => Provider::OpenAI,
-                'anthropic' => Provider::Anthropic,
-                'gemini', 'google' => Provider::Gemini,
-                'deepseek' => Provider::DeepSeek,
-                'ollama' => Provider::Ollama,
-                'mistral' => Provider::Mistral,
-                'groq' => Provider::Groq,
-                'xai', 'grok' => Provider::XAI,
-                'voyageai', 'voyage' => Provider::VoyageAI,
-                default => throw new \InvalidArgumentException("Unknown provider: {$provider}")
-            };
-        }
-
-        $this->provider = $provider;
+        $this->provider = is_string($provider) ? $this->resolveCustomProvider($provider) : $provider->value;
 
         return $this;
     }
@@ -937,7 +918,7 @@ abstract class BaseLlmAgent extends BaseAgent
                 'system_prompt' => $this->getInstructionsWithMemory($context),
             ],
             metadata: [
-                'provider' => $this->getProvider()->value,
+                'provider' => $this->getProvider(),
                 'temperature' => $this->getTemperature(),
                 'max_tokens' => $this->getMaxTokens(),
                 'top_p' => $this->getTopP(),

--- a/src/Agents/BaseLlmAgent.php
+++ b/src/Agents/BaseLlmAgent.php
@@ -317,7 +317,7 @@ abstract class BaseLlmAgent extends BaseAgent
             };
         }
 
-        $this->provider = $provider;
+        $this->provider = $provider instanceof Provider ? $provider->value : $provider;
 
         return $this;
     }

--- a/tests/Feature/AgentAttachmentsIntegrationTest.php
+++ b/tests/Feature/AgentAttachmentsIntegrationTest.php
@@ -393,7 +393,7 @@ it('handles provider-specific attachment support gracefully', function () {
 
         protected string $model = 'gpt-4o';
 
-        protected ?Provider $provider = Provider::OpenAI;
+        protected ?string $provider = Provider::OpenAI->value;
 
         public function execute(mixed $input, AgentContext $context): mixed
         {
@@ -423,7 +423,7 @@ it('handles provider-specific attachment support gracefully', function () {
 
         protected string $model = 'gemini-2.0-flash';
 
-        protected ?Provider $provider = Provider::Gemini;
+        protected ?string $provider = Provider::Gemini->value;
 
         public function execute(mixed $input, AgentContext $context): mixed
         {

--- a/tests/Feature/ProviderAttachmentSupportTest.php
+++ b/tests/Feature/ProviderAttachmentSupportTest.php
@@ -17,12 +17,12 @@ it('correctly identifies provider support for attachments', function () {
 
         protected string $model = 'gpt-4o';
 
-        protected ?Provider $provider = Provider::OpenAI;
+        protected ?string $provider = Provider::OpenAI->value;
 
         public function getProviderInfo(): array
         {
             return [
-                'provider' => $this->getProvider()->value,
+                'provider' => $this->getProvider(),
                 'model' => $this->getModel(),
                 'supports_images' => true,
                 'supports_documents' => false,
@@ -48,12 +48,12 @@ it('correctly identifies provider support for attachments', function () {
 
         protected string $model = 'claude-3-5-sonnet-latest';
 
-        protected ?Provider $provider = Provider::Anthropic;
+        protected ?string $provider = Provider::Anthropic->value;
 
         public function getProviderInfo(): array
         {
             return [
-                'provider' => $this->getProvider()->value,
+                'provider' => $this->getProvider(),
                 'model' => $this->getModel(),
                 'supports_images' => true,
                 'supports_documents' => true,
@@ -79,12 +79,12 @@ it('correctly identifies provider support for attachments', function () {
 
         protected string $model = 'gemini-2.0-flash';
 
-        protected ?Provider $provider = Provider::Gemini;
+        protected ?string $provider = Provider::Gemini->value;
 
         public function getProviderInfo(): array
         {
             return [
-                'provider' => $this->getProvider()->value,
+                'provider' => $this->getProvider(),
                 'model' => $this->getModel(),
                 'supports_images' => true,
                 'supports_documents' => true,
@@ -112,14 +112,14 @@ it('handles provider limitations gracefully', function () {
 
         protected string $model = 'gpt-4o';
 
-        protected ?Provider $provider = Provider::OpenAI;
+        protected ?string $provider = Provider::OpenAI->value;
 
         public function execute(mixed $input, AgentContext $context): mixed
         {
             // Simulate what happens when OpenAI receives documents
             $documents = $context->getState('prism_documents', []);
 
-            if (! empty($documents) && $this->getProvider() === Provider::OpenAI) {
+            if (! empty($documents) && $this->getProvider() === Provider::OpenAI->value) {
                 // In real scenario, this would throw an API error
                 // but for testing, we'll return a descriptive message
                 return 'OpenAI does not support document uploads';
@@ -162,7 +162,7 @@ it('suggests alternative providers for unsupported features', function () {
 
         public function suggestAlternativeForDocuments(): array
         {
-            if ($this->getProvider() === Provider::OpenAI) {
+            if ($this->getProvider() === Provider::OpenAI->value) {
                 return [
                     'current_provider' => 'OpenAI',
                     'limitation' => 'Documents not supported',
@@ -174,7 +174,7 @@ it('suggests alternative providers for unsupported features', function () {
                 ];
             }
 
-            return ['current_provider' => $this->getProvider()->value, 'limitation' => 'None'];
+            return ['current_provider' => $this->getProvider(), 'limitation' => 'None'];
         }
     };
 
@@ -203,7 +203,7 @@ it('validates model capabilities for attachments', function () {
 
         protected string $model = 'gpt-4o';
 
-        protected ?Provider $provider = Provider::OpenAI;
+        protected ?string $provider = Provider::OpenAI->value;
 
         public function supportsImages(): bool
         {
@@ -222,7 +222,7 @@ it('validates model capabilities for attachments', function () {
 
         protected string $model = 'gpt-3.5-turbo';
 
-        protected ?Provider $provider = Provider::OpenAI;
+        protected ?string $provider = Provider::OpenAI->value;
 
         public function supportsImages(): bool
         {
@@ -249,16 +249,16 @@ it('provides clear error messages for unsupported attachments', function () {
 
         protected string $model = 'gpt-4o';
 
-        protected ?Provider $provider = Provider::OpenAI;
+        protected ?string $provider = Provider::OpenAI->value;
 
         public function validateAttachments(array $images, array $documents): array
         {
             $errors = [];
 
-            if (! empty($documents) && $this->getProvider() === Provider::OpenAI) {
+            if (! empty($documents) && $this->getProvider() === Provider::OpenAI->value) {
                 $errors[] = sprintf(
                     'Provider %s does not support document uploads. Consider using Anthropic Claude or Google Gemini instead.',
-                    $this->getProvider()->value
+                    $this->getProvider()
                 );
             }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Vizra\VizraADK\Tests;
 
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Prism\Prism\PrismServiceProvider;
 use Vizra\VizraADK\Providers\AgentServiceProvider;
 
 class TestCase extends Orchestra
@@ -13,6 +14,7 @@ class TestCase extends Orchestra
         return [
             LivewireServiceProvider::class,
             AgentServiceProvider::class,
+            PrismServiceProvider::class,
         ];
     }
 

--- a/tests/Unit/Agents/BaseLlmAgentTest.php
+++ b/tests/Unit/Agents/BaseLlmAgentTest.php
@@ -1,12 +1,17 @@
 <?php
 
 use Prism\Prism\Enums\Provider;
+use Prism\Prism\PrismManager;
 use Prism\Prism\ValueObjects\ProviderTool;
 use Vizra\VizraADK\Agents\BaseLlmAgent;
 use Vizra\VizraADK\System\AgentContext;
 
 beforeEach(function () {
     $this->agent = new TestLlmAgent;
+
+    $this->app[PrismManager::class]->extend('mock', function () {
+        return new class extends \Prism\Prism\Providers\Provider {};
+    });
 });
 
 it('can get agent instructions', function () {
@@ -21,7 +26,7 @@ it('can get agent model', function () {
 
 it('can get provider', function () {
     $provider = $this->agent->getProvider();
-    expect($provider)->toBeInstanceOf(Provider::class);
+    expect($provider)->toBe(config('vizra-adk.default_provider'));
 });
 
 it('can get temperature', function () {
@@ -127,6 +132,15 @@ it('can create agent with showInChatUi disabled', function () {
     expect($hiddenAgent->getShowInChatUi())->toBeFalse();
 });
 
+it('can set custom provider', function () {
+    $this->agent->setProvider('mock');
+    expect($this->agent->getProvider())->toBe('mock');
+});
+
+it('throws exception for invalid provider', function () {
+    $this->agent->setProvider('invalid-provider');
+})->throws(\InvalidArgumentException::class, 'Provider [invalid-provider] is not supported.');
+
 /**
  * Test implementation of BaseLlmAgent for testing purposes
  */
@@ -158,7 +172,7 @@ class TestLlmAgent extends BaseLlmAgent
         return $this->model;
     }
 
-    public function getProvider(): Provider
+    public function getProvider(): string
     {
         return parent::getProvider();
     }


### PR DESCRIPTION
**Summary**
Add support for Prism custom providers

**Description**
This PR introduces support for using Prism custom providers in our application.

**Problem**
Previously, the only way to use custom providers was to override the ⁠execute method of the ⁠BaseLlmAgent class, as the ⁠getProvider() method was restricted to returning a ⁠Provider enum value. This limitation became apparent when attempting to integrate Azure OpenAI models, which are not yet natively supported by Prism.

**Solution**
This change enables the use of custom providers without requiring workarounds or method overrides, providing a cleaner and more maintainable approach to extending provider support.

**Changes**
	- Modified provider handling to accept custom providers beyond the predefined ⁠Provider enum 
	- Updated ⁠getProvider() method implementation to support custom provider instances 	
	- Removed the need to override the ⁠execute method for custom provider integration
