### PR TITLE
Fix Windows path handling in AgentDiscovery::fileToClassName()

### DIFF
--- a/src/Services/AgentDiscovery.php
+++ b/src/Services/AgentDiscovery.php
@@ -89,7 +89,7 @@ class AgentDiscovery
                 }
 
                 // Check again after loading
-                if (! class_exists($className)) {
+                if (!class_exists($className)) {
                     continue;
                 }
             }
@@ -138,7 +138,12 @@ class AgentDiscovery
      */
     protected function fileToClassName(\SplFileInfo $file, string $namespace, string $directory): ?string
     {
-        $relativePath = str_replace($directory.'/', '', $file->getPathname());
+        // Normalize paths to use forward slashes for cross-platform compatibility
+        $directory = rtrim(str_replace('\\', '/', $directory), '/');
+        $filePath = str_replace('\\', '/', $file->getPathname());
+
+        // Get relative path from directory to file
+        $relativePath = str_replace($directory . '/', '', $filePath);
         $relativePath = str_replace('.php', '', $relativePath);
         $relativePath = str_replace('/', '\\', $relativePath);
 

--- a/tests/Unit/Services/AgentDiscoveryTest.php
+++ b/tests/Unit/Services/AgentDiscoveryTest.php
@@ -245,6 +245,48 @@ class SubAgent extends BaseLlmAgent
         File::deleteDirectory($testDir);
     }
 
+    public function test_file_to_class_name_handles_windows_paths()
+    {
+        $discovery = new AgentDiscovery;
+        
+        // Create a mock SplFileInfo with Windows-style path
+        $file = $this->createMock(\SplFileInfo::class);
+        $file->method('getPathname')->willReturn('C:\\Users\\test\\app\\Agents\\TestAgent.php');
+        
+        $namespace = 'App\\Agents';
+        $directory = 'C:\\Users\\test\\app\\Agents';
+        
+        // Use reflection to test the protected method
+        $reflection = new \ReflectionClass($discovery);
+        $method = $reflection->getMethod('fileToClassName');
+        $method->setAccessible(true);
+        
+        $result = $method->invoke($discovery, $file, $namespace, $directory);
+        
+        $this->assertEquals('App\\Agents\\TestAgent', $result);
+    }
+
+    public function test_file_to_class_name_handles_unix_paths()
+    {
+        $discovery = new AgentDiscovery;
+        
+        // Create a mock SplFileInfo with Unix-style path
+        $file = $this->createMock(\SplFileInfo::class);
+        $file->method('getPathname')->willReturn('/var/www/app/Agents/TestAgent.php');
+        
+        $namespace = 'App\\Agents';
+        $directory = '/var/www/app/Agents';
+        
+        // Use reflection to test the protected method
+        $reflection = new \ReflectionClass($discovery);
+        $method = $reflection->getMethod('fileToClassName');
+        $method->setAccessible(true);
+        
+        $result = $method->invoke($discovery, $file, $namespace, $directory);
+        
+        $this->assertEquals('App\\Agents\\TestAgent', $result);
+    }
+
     protected function createTestAgent(string $dir, string $className, string $baseClass, string $agentName): void
     {
         $baseClassName = class_basename($baseClass);


### PR DESCRIPTION
On Windows, the `fileToClassName` method was generating malformed class names due to mixed path separators, resulting in class names like:
```
App\Agents\C:\Users\hello\Herd\vizra\app\Agents\CustomerSupportAgent
```

**Solution:** Normalize all paths to use forward slashes before processing to ensure cross-platform compatibility.