### PR TITLE
Fix misplaced closing tag in trace-span partial

### DIFF
--- a/resources/views/partials/trace-span.blade.php
+++ b/resources/views/partials/trace-span.blade.php
@@ -128,7 +128,7 @@
                                 @endif
                             </div>
                         </div>
-                    @endif>
+                    @endif
                     @if(!empty($span['input_data']))
                         @include('vizra-adk::components.json-viewer', [
                             'data' => $span['input_data'],


### PR DESCRIPTION
Removes an extra closing angle bracket after an `@endif` directive in trace-span.blade.php

Before:

<img width="786" height="269" alt="image" src="https://github.com/user-attachments/assets/7ca52250-e1d1-4db4-83e4-9473ef126a5c" />


After:

<img width="625" height="439" alt="image" src="https://github.com/user-attachments/assets/3bf1d81b-1d59-4d2d-a787-7c55d593b15f" />
