### PR TITLE
Fix version constraint format for prism-php/prism

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.2",
     "laravel/framework": "^11.0|^12.0",
-    "prism-php/prism": "^v0.84.0",
+    "prism-php/prism": "^0.84.0",
     "league/csv": "^9.23",
     "livewire/livewire": "^3.0"
   },


### PR DESCRIPTION
using "v" in the version constraint causes issues when installing vizra and prism is already installed