### PR TITLE
fix: Fixed issue where user ID wasn't assigned to session creation.

### DIFF
--- a/src/Execution/AgentExecutor.php
+++ b/src/Execution/AgentExecutor.php
@@ -285,7 +285,7 @@ class AgentExecutor
         $agentName = $this->getAgentName();
 
         // Load or create agent context
-        $agentContext = $stateManager->loadContext($agentName, $sessionId, $this->input);
+        $agentContext = $stateManager->loadContext($agentName, $sessionId, $this->input, $this->user?->getKey());
 
         // Add user information to context
         if ($this->user) {

--- a/src/Jobs/AgentJob.php
+++ b/src/Jobs/AgentJob.php
@@ -68,7 +68,7 @@ class AgentJob implements ShouldQueue
             $agentName = $this->getAgentName();
 
             // Load or create agent context
-            $agentContext = $stateManager->loadContext($agentName, $this->sessionId, $this->input);
+            $agentContext = $stateManager->loadContext($agentName, $this->sessionId, $this->input, $this->context['user']['id'] ?? null);
 
             // Restore context from job data
             $this->restoreContext($agentContext);

--- a/src/Services/AgentManager.php
+++ b/src/Services/AgentManager.php
@@ -85,13 +85,14 @@ class AgentManager
      * @param  string  $agentNameOrClass  The name or class of the agent to run.
      * @param  mixed  $input  The input for the agent.
      * @param  string|null  $sessionId  Optional session ID. If null, a new session is created/managed.
+     * @param  int|null  $userId  Optional user ID for user-specific memory.
      * @return mixed The final response from the agent.
      *
      * @throws \Vizra\VizraADK\Exceptions\AgentNotFoundException
      * @throws \Vizra\VizraADK\Exceptions\AgentConfigurationException
      * @throws \Throwable
      */
-    public function run(string $agentNameOrClass, mixed $input, ?string $sessionId = null): mixed
+    public function run(string $agentNameOrClass, mixed $input, ?string $sessionId = null, ?int $userId = null): mixed
     {
         // Resolve to agent name first
         $agentName = $this->registry->resolveAgentName($agentNameOrClass);
@@ -103,7 +104,7 @@ class AgentManager
 
         // Load or create context
         // The StateManager's loadContext now takes agentName first.
-        $context = $this->stateManager->loadContext($agentName, $sessionId, $input);
+        $context = $this->stateManager->loadContext($agentName, $sessionId, $input, $userId);
 
 
         Event::dispatch(new AgentExecutionStarting($context, $agentName, $input));

--- a/tests/Unit/Services/AgentManagerTest.php
+++ b/tests/Unit/Services/AgentManagerTest.php
@@ -95,7 +95,7 @@ it('can run agent', function () {
 
     $this->mockStateManager
         ->shouldReceive('loadContext')
-        ->with($agentName, $sessionId, $input)
+        ->with($agentName, $sessionId, $input, null)
         ->once()
         ->andReturn($mockContext);
 


### PR DESCRIPTION
When testing, I noticed that the user ID wasn't assigned to sessions, even when the user was set.  I'm not sure if this is a bug or intended since the function comments mentioned the `$userId` was for user-specific memory.  Either way, I set this up so it will use the provided user's ID in that slot in case it's helpful.