### PR TITLE
fix: provider type mismatching

### DIFF
--- a/src/Agents/BaseLlmAgent.php
+++ b/src/Agents/BaseLlmAgent.php
@@ -60,7 +60,7 @@ abstract class BaseLlmAgent extends BaseAgent
 
     protected string $model = '';
 
-    protected ?string $provider = null;
+    protected ?Provider $provider = null;
 
     protected ?float $temperature = null;
 


### PR DESCRIPTION
Based to the [documentation](https://vizra.ai/docs/adk/api/providers) `$provider` type should be `?Provider` but `src/Agents/BaseLlmAgent.php` has `?string` causing type error.

> Symfony\Component\ErrorHandler\Error\FatalError
> Type of App\Agents\KnowladgeBaseAgent::$provider must be ?string (as in class Vizra\VizraADK\Agents\BaseLlmAgent)

This pr fixes the issue.