### PR TITLE
Allow string user identifiers across agent state and memory

### DIFF
--- a/database/migrations/2024_03_10_000000_create_agent_sessions_table.php
+++ b/database/migrations/2024_03_10_000000_create_agent_sessions_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create($tableName, function (Blueprint $table) {
             $table->id();
             $table->string('session_id')->index();
-            $table->foreignId('user_id')->nullable()->index()->comment('Optional link to users table');
+            $table->string('user_id', 255)->nullable()->index()->comment('Optional link to users table or custom identifier');
             $table->foreignId('agent_memory_id')->nullable()->index()->comment('Link to agent memory');
             $table->string('agent_name')->index();
             $table->json('state_data')->nullable();

--- a/database/migrations/2024_03_10_000002_create_agent_memories_table.php
+++ b/database/migrations/2024_03_10_000002_create_agent_memories_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create($memoriesTableName, function (Blueprint $table) {
             $table->id();
             $table->string('agent_name')->index();
-            $table->foreignId('user_id')->nullable()->index()->comment('Optional link to users table for user-specific memories');
+            $table->string('user_id', 255)->nullable()->index()->comment('Optional link to users table or custom identifier for user-specific memories');
             $table->longText('memory_summary')->nullable()->comment('Summarized knowledge from all sessions');
             $table->json('memory_data')->nullable()->comment('Structured memory data, facts, preferences, etc.');
             $table->json('key_learnings')->nullable()->comment('Important insights learned across sessions');

--- a/database/migrations/2025_10_05_000000_update_agent_user_ids_to_string.php
+++ b/database/migrations/2025_10_05_000000_update_agent_user_ids_to_string.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $sessionsTableName = config('vizra-adk.tables.agent_sessions', 'agent_sessions');
+        $memoriesTableName = config('vizra-adk.tables.agent_memories', 'agent_memories');
+
+        Schema::table($sessionsTableName, function (Blueprint $table) {
+            $table->string('user_id', 255)->nullable()->comment('Optional link to users table or custom identifier')->change();
+        });
+
+        Schema::table($memoriesTableName, function (Blueprint $table) {
+            $table->string('user_id', 255)->nullable()->comment('Optional link to users table or custom identifier for user-specific memories')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $sessionsTableName = config('vizra-adk.tables.agent_sessions', 'agent_sessions');
+        $memoriesTableName = config('vizra-adk.tables.agent_memories', 'agent_memories');
+
+        Schema::table($sessionsTableName, function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->comment('Optional link to users table')->change();
+        });
+
+        Schema::table($memoriesTableName, function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->comment('Optional link to users table for user-specific memories')->change();
+        });
+    }
+};

--- a/src/Models/AgentMemory.php
+++ b/src/Models/AgentMemory.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  *
  * @property int $id
  * @property string $agent_name
- * @property int|null $user_id
+ * @property int|string|null $user_id
  * @property string|null $memory_summary
  * @property array|null $memory_data
  * @property array|null $key_learnings
@@ -58,7 +58,7 @@ class AgentMemory extends Model
         $relationship = $this->hasMany(AgentSession::class, 'agent_name', 'agent_name');
 
         // If this memory is user-specific, filter sessions by user_id
-        if ($this->user_id) {
+        if ($this->user_id !== null) {
             $relationship->where('user_id', $this->user_id);
         }
 

--- a/src/Models/AgentSession.php
+++ b/src/Models/AgentSession.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Str;
  *
  * @property int $id
  * @property string $session_id
- * @property int|null $user_id
+ * @property int|string|null $user_id
  * @property string $agent_name
  * @property array $state_data
  * @property \Illuminate\Support\Carbon $created_at

--- a/src/Services/AgentManager.php
+++ b/src/Services/AgentManager.php
@@ -85,14 +85,14 @@ class AgentManager
      * @param  string  $agentNameOrClass  The name or class of the agent to run.
      * @param  mixed  $input  The input for the agent.
      * @param  string|null  $sessionId  Optional session ID. If null, a new session is created/managed.
-     * @param  int|null  $userId  Optional user ID for user-specific memory.
+     * @param  int|string|null  $userId  Optional user identifier for user-specific memory.
      * @return mixed The final response from the agent.
      *
      * @throws \Vizra\VizraADK\Exceptions\AgentNotFoundException
      * @throws \Vizra\VizraADK\Exceptions\AgentConfigurationException
      * @throws \Throwable
      */
-    public function run(string $agentNameOrClass, mixed $input, ?string $sessionId = null, ?int $userId = null): mixed
+    public function run(string $agentNameOrClass, mixed $input, ?string $sessionId = null, int|string|null $userId = null): mixed
     {
         // Resolve to agent name first
         $agentName = $this->registry->resolveAgentName($agentNameOrClass);

--- a/src/Services/MemoryManager.php
+++ b/src/Services/MemoryManager.php
@@ -17,7 +17,7 @@ class MemoryManager
     /**
      * Get or create memory for an agent and user.
      */
-    public function getOrCreateMemory(string $agentName, ?int $userId = null): AgentMemory
+    public function getOrCreateMemory(string $agentName, int|string|null $userId = null): AgentMemory
     {
         return AgentMemory::firstOrCreate([
             'agent_name' => $agentName,
@@ -53,7 +53,7 @@ class MemoryManager
     /**
      * Get memory context for an agent to include in their instructions.
      */
-    public function getMemoryContext(string $agentName, ?int $userId = null, int $maxLength = 1000): string
+    public function getMemoryContext(string $agentName, int|string|null $userId = null, int $maxLength = 1000): string
     {
         $memory = AgentMemory::where('agent_name', $agentName)
             ->where('user_id', $userId)
@@ -69,7 +69,7 @@ class MemoryManager
     /**
      * Get memory context as an array for testing and programmatic access.
      */
-    public function getMemoryContextArray(string $agentName, ?int $userId = null): array
+    public function getMemoryContextArray(string $agentName, int|string|null $userId = null): array
     {
         $memory = AgentMemory::where('agent_name', $agentName)
             ->where('user_id', $userId)
@@ -136,7 +136,7 @@ class MemoryManager
     /**
      * Add a learning to memory.
      */
-    public function addLearning(string $agentName, string $learning, ?int $userId = null): void
+    public function addLearning(string $agentName, string $learning, int|string|null $userId = null): void
     {
         $memory = $this->getOrCreateMemory($agentName, $userId);
 
@@ -155,7 +155,7 @@ class MemoryManager
     /**
      * Update memory data with facts or preferences.
      */
-    public function updateMemoryData(string $agentName, array $data, ?int $userId = null): void
+    public function updateMemoryData(string $agentName, array $data, int|string|null $userId = null): void
     {
         $memory = $this->getOrCreateMemory($agentName, $userId);
 
@@ -173,7 +173,7 @@ class MemoryManager
     /**
      * Add a fact to memory data.
      */
-    public function addFact(string $agentName, string $key, $value, ?int $userId = null): void
+    public function addFact(string $agentName, string $key, $value, int|string|null $userId = null): void
     {
         $memory = $this->getOrCreateMemory($agentName, $userId);
 
@@ -191,7 +191,7 @@ class MemoryManager
     /**
      * Update memory summary.
      */
-    public function updateSummary(string $agentName, string $summary, ?int $userId = null): void
+    public function updateSummary(string $agentName, string $summary, int|string|null $userId = null): void
     {
         $memory = $this->getOrCreateMemory($agentName, $userId);
 
@@ -206,7 +206,7 @@ class MemoryManager
     /**
      * Get recent conversations from memory.
      */
-    public function getRecentConversations(string $agentName, ?int $userId = null, int $limit = 5): Collection
+    public function getRecentConversations(string $agentName, int|string|null $userId = null, int $limit = 5): Collection
     {
         $memory = AgentMemory::where('agent_name', $agentName)
             ->where('user_id', $userId)
@@ -241,7 +241,7 @@ class MemoryManager
     /**
      * Increment the session count for an agent's memory.
      */
-    public function incrementSessionCount(string $agentName, ?int $userId = null): void
+    public function incrementSessionCount(string $agentName, int|string|null $userId = null): void
     {
         $memory = $this->getOrCreateMemory($agentName, $userId);
 

--- a/src/Services/StateManager.php
+++ b/src/Services/StateManager.php
@@ -28,9 +28,9 @@ class StateManager
      * @param  string  $agentName  The name of the agent.
      * @param  string|null  $sessionId  Optional session ID. If null, a new session is created.
      * @param  mixed|null  $userInput  Optional initial user input for a new context.
-     * @param  int|null  $userId  Optional user ID for user-specific memory.
+     * @param  int|string|null  $userId  Optional user identifier for user-specific memory.
      */
-    public function loadContext(string $agentName, ?string $sessionId = null, mixed $userInput = null, ?int $userId = null): AgentContext
+    public function loadContext(string $agentName, ?string $sessionId = null, mixed $userInput = null, int|string|null $userId = null): AgentContext
     {
         $sessionId = $sessionId ?: (string) Str::uuid();
         $agentSession = AgentSession::firstOrCreate(
@@ -137,7 +137,7 @@ class StateManager
     /**
      * Get memory context for an agent.
      */
-    public function getMemoryContext(string $agentName, ?int $userId = null): string
+    public function getMemoryContext(string $agentName, int|string|null $userId = null): string
     {
         return $this->memoryManager->getMemoryContext($agentName, $userId);
     }
@@ -145,7 +145,7 @@ class StateManager
     /**
      * Add a learning to memory.
      */
-    public function addLearning(string $agentName, string $learning, ?int $userId = null): void
+    public function addLearning(string $agentName, string $learning, int|string|null $userId = null): void
     {
         $this->memoryManager->addLearning($agentName, $learning, $userId);
     }
@@ -153,7 +153,7 @@ class StateManager
     /**
      * Update memory data.
      */
-    public function updateMemoryData(string $agentName, array $data, ?int $userId = null): void
+    public function updateMemoryData(string $agentName, array $data, int|string|null $userId = null): void
     {
         $this->memoryManager->updateMemoryData($agentName, $data, $userId);
     }

--- a/tests/Unit/Models/AgentMemoryTest.php
+++ b/tests/Unit/Models/AgentMemoryTest.php
@@ -71,6 +71,26 @@ it('has many sessions relationship', function () {
     expect($memory->sessions->pluck('id')->toArray())->toBe([$session1->id, $session2->id]);
 });
 
+it('filters sessions by string user identifier', function () {
+    $memory = AgentMemory::create([
+        'agent_name' => 'test-agent',
+        'user_id' => 'user-abc',
+    ]);
+
+    $matchingSession = AgentSession::create([
+        'agent_name' => 'test-agent',
+        'user_id' => 'user-abc',
+    ]);
+
+    AgentSession::create([
+        'agent_name' => 'test-agent',
+        'user_id' => 'user-other',
+    ]);
+
+    expect($memory->sessions)->toHaveCount(1);
+    expect($memory->sessions->first()->id)->toBe($matchingSession->id);
+});
+
 it('can find memory by agent name', function () {
     $memory = AgentMemory::create([
         'agent_name' => 'unique-agent',

--- a/tests/Unit/Models/AgentSessionTest.php
+++ b/tests/Unit/Models/AgentSessionTest.php
@@ -54,13 +54,20 @@ it('casts state data to array', function () {
     expect($session->state_data['nested']['data'])->toBe('value');
 });
 
-it('can associate user id', function () {
-    $session = AgentSession::create([
+it('can associate user identifier', function () {
+    $numericSession = AgentSession::create([
         'user_id' => 123,
         'agent_name' => 'test-agent',
     ]);
 
-    expect($session->user_id)->toBe(123);
+    expect($numericSession->user_id)->toBe(123);
+
+    $stringSession = AgentSession::create([
+        'user_id' => 'user-123',
+        'agent_name' => 'test-agent',
+    ]);
+
+    expect($stringSession->user_id)->toBe('user-123');
 });
 
 it('has many messages relationship', function () {

--- a/tests/Unit/Services/MemoryManagerTest.php
+++ b/tests/Unit/Services/MemoryManagerTest.php
@@ -149,3 +149,26 @@ it('handles memory operations for non-existent agent gracefully', function () {
     expect($memory->memory_data['key'])->toBe('value');
     expect($memory->memory_summary)->toBe('Summary');
 });
+
+it('supports string user identifiers across operations', function () {
+    $agentName = 'string-user-agent';
+    $userId = 'user-xyz';
+
+    $this->memoryManager->addLearning($agentName, 'Learning for string user', $userId);
+    $this->memoryManager->updateMemoryData($agentName, ['preference' => 'dark-mode'], $userId);
+    $this->memoryManager->updateSummary($agentName, 'Summary for string user', $userId);
+
+    $memory = AgentMemory::where('agent_name', $agentName)
+        ->where('user_id', $userId)
+        ->first();
+
+    expect($memory)->not->toBeNull();
+    expect($memory->user_id)->toBe($userId);
+    expect($memory->key_learnings)->toContain('Learning for string user');
+    expect($memory->memory_data['preference'])->toBe('dark-mode');
+    expect($memory->memory_summary)->toBe('Summary for string user');
+
+    $context = $this->memoryManager->getMemoryContextArray($agentName, $userId);
+    expect($context['key_learnings'])->toContain('Learning for string user');
+    expect($context['facts']['preference'])->toBe('dark-mode');
+});

--- a/tests/Unit/Services/StateManagerTest.php
+++ b/tests/Unit/Services/StateManagerTest.php
@@ -28,6 +28,19 @@ it('can load context with new session', function () {
     expect($context->getAllState())->toBeArray()->toBeEmpty();
 });
 
+it('stores string user identifiers on context creation', function () {
+    $agentName = 'string-user-agent';
+    $userId = 'user-123';
+
+    $context = $this->stateManager->loadContext($agentName, null, 'hello', $userId);
+
+    expect($context)->toBeInstanceOf(AgentContext::class);
+
+    $session = AgentSession::where('agent_name', $agentName)->first();
+    expect($session)->not->toBeNull();
+    expect($session->user_id)->toBe($userId);
+});
+
 it('can load context with existing session', function () {
     $agentName = 'test-agent';
     $sessionId = (string) Str::uuid();


### PR DESCRIPTION
## Summary
- allow the agent state, memory, and manager services to accept `int|string|null` user identifiers and propagate them when saving or retrieving context
- update agent memory and session models plus base migrations to treat `user_id` as a flexible string column and avoid falsy string pitfalls
- add a follow-up migration and new unit coverage to ensure string user IDs are stored and retrieved correctly across sessions and memories

