### PR TITLE
 Fix streaming text accumulation bug

### DIFF
--- a/src/Models/AgentMessage.php
+++ b/src/Models/AgentMessage.php
@@ -32,45 +32,6 @@ class AgentMessage extends Model
     ];
 
     /**
-     * Set the content attribute, preventing double-encoding of already JSON-encoded strings.
-     * This handles cases where AI providers return JSON-encoded tool results.
-     *
-     * @param  mixed  $value
-     * @return void
-     */
-    public function setContentAttribute($value): void
-    {
-        // If value is already a JSON string (from AI provider), decode it once
-        // to prevent double-encoding by Laravel's JSON cast
-        if (is_string($value) && $this->isJson($value)) {
-            // Decode the JSON string, then let Laravel's JSON cast re-encode it
-            $decoded = json_decode($value, true);
-            $this->attributes['content'] = json_encode($decoded);
-        } else {
-            // For everything else (plain strings, arrays, objects),
-            // let Laravel's JSON cast handle it normally by encoding
-            $this->attributes['content'] = json_encode($value);
-        }
-    }
-
-    /**
-     * Check if a string is valid JSON
-     *
-     * @param  string  $string
-     * @return bool
-     */
-    protected function isJson(string $string): bool
-    {
-        if (empty($string)) {
-            return false;
-        }
-
-        json_decode($string);
-
-        return json_last_error() === JSON_ERROR_NONE;
-    }
-
-    /**
      * Get the session this message belongs to.
      */
     public function session(): BelongsTo


### PR DESCRIPTION
## Summary
  Fixes streaming response handling where text/thinking content wasn't being accumulated properly during LLM streaming.

  Fixes https://github.com/vizra-ai/vizra-adk/issues/79

  ## Changes
  - **BaseLlmAgent.php**: Access `Chunk.text` property instead of non-existent `delta` property
  - **BaseLlmAgent.php**: Use `property_exists($event, 'text')` for Chunk detection instead of `method_exists($event, 'type')`
  - **AgentMessage.php**: Remove `setContentAttribute()` mutator that was causing double-encoding by manually calling `json_encode()` before Laravel's JSON cast

  ## Root Cause
  The Prism library's `Chunk` objects expose text via the `text` property, not `delta`. The old code was trying to access a non-existent property, resulting in empty string accumulation during streaming.

  Additionally, the `setContentAttribute()` mutator was manually encoding content with `json_encode()`, which then got encoded again by Laravel's `'content' => 'json'` cast, resulting in double-encoded database values.
