### PR TITLE
fix: align prism-php dependency with changelog (v0.84 → v0.92)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   "require": {
     "php": "^8.2",
     "laravel/framework": "^11.0|^12.0",
-    "prism-php/prism": "^0.84.0",
+    "prism-php/prism": "^0.92.0",
     "league/csv": "^9.23",
     "livewire/livewire": "^3.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e81d2101817feca513fe6ba7912e1800",
+    "content-hash": "0f5dd06708b00abeeabb580b4f13a8cf",
     "packages": [
         {
             "name": "brick/math",
@@ -2629,16 +2629,16 @@
         },
         {
             "name": "prism-php/prism",
-            "version": "v0.84.0",
+            "version": "v0.92.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/prism-php/prism.git",
-                "reference": "c68a67d294bc8869370a3ff045ee226b625fd781"
+                "reference": "90cd46fd84d5135d4793d29310e86353bb111040"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/prism-php/prism/zipball/c68a67d294bc8869370a3ff045ee226b625fd781",
-                "reference": "c68a67d294bc8869370a3ff045ee226b625fd781",
+                "url": "https://api.github.com/repos/prism-php/prism/zipball/90cd46fd84d5135d4793d29310e86353bb111040",
+                "reference": "90cd46fd84d5135d4793d29310e86353bb111040",
                 "shasum": ""
             },
             "require": {
@@ -2654,11 +2654,11 @@
                 "pestphp/pest-plugin-arch": "^3.0",
                 "pestphp/pest-plugin-laravel": "^3.0",
                 "phpstan/extension-installer": "^1.3",
-                "phpstan/phpdoc-parser": "^1.24",
-                "phpstan/phpstan": "^1.11",
-                "phpstan/phpstan-deprecation-rules": "^1.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
                 "projektgopher/whisky": "^0.7.0",
-                "rector/rector": "^1.1",
+                "rector/rector": "^2.1",
                 "spatie/laravel-ray": "^1.39",
                 "symplify/rule-doc-generator-contracts": "^11.2"
             },
@@ -2694,7 +2694,7 @@
             "description": "A powerful Laravel package for integrating Large Language Models (LLMs) into your applications.",
             "support": {
                 "issues": "https://github.com/prism-php/prism/issues",
-                "source": "https://github.com/prism-php/prism/tree/v0.84.0"
+                "source": "https://github.com/prism-php/prism/tree/v0.92.0"
             },
             "funding": [
                 {
@@ -2702,7 +2702,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-12T17:08:33+00:00"
+            "time": "2025-10-14T20:09:20+00:00"
         },
         {
             "name": "psr/clock",

--- a/src/Agents/BaseLlmAgent.php
+++ b/src/Agents/BaseLlmAgent.php
@@ -251,16 +251,16 @@ abstract class BaseLlmAgent extends BaseAgent
         if ($this->provider === null) {
             $defaultProvider = config('vizra-adk.default_provider', 'openai');
             $this->provider = match ($defaultProvider) {
-                'openai' => Provider::OpenAI,
-                'anthropic' => Provider::Anthropic,
-                'gemini', 'google' => Provider::Gemini,
-                'deepseek' => Provider::DeepSeek,
-                'ollama' => Provider::Ollama,
-                'mistral' => Provider::Mistral,
-                'groq' => Provider::Groq,
-                'xai', 'grok' => Provider::XAI,
-                'voyageai', 'voyage' => Provider::VoyageAI,
-                'openrouter' => Provider::OpenRouter,
+                'openai' => Provider::OpenAI->value,
+                'anthropic' => Provider::Anthropic->value,
+                'gemini', 'google' => Provider::Gemini->value,
+                'deepseek' => Provider::DeepSeek->value,
+                'ollama' => Provider::Ollama->value,
+                'mistral' => Provider::Mistral->value,
+                'groq' => Provider::Groq->value,
+                'xai', 'grok' => Provider::XAI->value,
+                'voyageai', 'voyage' => Provider::VoyageAI->value,
+                'openrouter' => Provider::OpenRouter->value,
                 default => $this->resolveCustomProvider($defaultProvider),
             };
         }


### PR DESCRIPTION
## Description
Fixes dependency mismatch where CHANGELOG claimed Prism v0.92.0 streaming support but composer.json still required v0.84.0

## Problem
The CHANGELOG.md documented support for "Prism v0.92.0 Streaming Support" with type-safe StreamEvent objects, but the actual dependency in `composer.json` was still pinned to `^0.84.0`. 

## Changes
  - **Upgraded** `prism-php/prism` from `^0.84.0` to `^0.92.0` in composer.json
  - **Fixed** `BaseLlmAgent.php` to use `Provider::*->value` instead of direct enum cases
  - **Updated** composer.lock with new dependency tree

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally
- [ ] Added new tests
- [ ] Tested manually

## Checklist
- [ ] Code follows style guidelines
- [ ] Self-review completed
- [ ]  Documentation updated
- [ ] No breaking changes (or documented)