### PR TITLE
Add Laravel Macroable trait support to core services (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,34 @@ class OrderLookupTool implements ToolInterface
 }
 ```
 
+## 🔧 Extending with Macros
+
+Vizra ADK supports Laravel's powerful macro pattern, allowing you to add custom methods to core classes without modifying the package:
+
+```php
+use Vizra\VizraADK\Services\AgentBuilder;
+use Vizra\VizraADK\Facades\Agent;
+use Illuminate\Database\Eloquent\Model;
+
+// Register a macro in your AppServiceProvider::boot()
+AgentBuilder::macro('track', function (Model $model) {
+    $this->trackedModel = $model;
+    return $this;
+});
+
+// Step 1: Use the macro when registering the agent
+Agent::build(CustomerSupportAgent::class)
+    ->track(Unit::find(12))  // Track token usage for analytics
+    ->register();
+
+// Step 2: Run the agent using the executor API
+$response = CustomerSupportAgent::run('I need help')
+    ->forUser($user)
+    ->go();
+```
+
+Learn more in the [Macros Documentation](docs/MACROS.md).
+
 ## 📚 Full Documentation
 
 For comprehensive documentation, tutorials, and API reference, visit:

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -1,0 +1,306 @@
+# Laravel Macros and Mixins Support
+
+Vizra ADK now supports Laravel's powerful macros and mixins pattern, allowing you to extend the package's functionality with custom methods without modifying the core code.
+
+## What are Macros?
+
+Macros allow you to add custom methods to classes at runtime. This is useful for:
+- Adding custom tracking or analytics
+- Integrating with third-party services
+- Adding domain-specific functionality
+- Creating reusable patterns across your application
+
+## Supported Classes
+
+The following Vizra ADK classes support macros:
+
+- `AgentManager` - Access via `Agent` facade
+- `AgentBuilder` - Fluent builder interface
+- `WorkflowManager` - Access via `Workflow` facade
+
+## Basic Usage
+
+### Registering a Macro
+
+Register macros in your `AppServiceProvider::boot()` method:
+
+```php
+use Vizra\VizraADK\Services\AgentBuilder;
+use Vizra\VizraADK\Facades\Agent;
+use Illuminate\Database\Eloquent\Model;
+
+public function boot(): void
+{
+    // Add a tracking macro for analytics
+    AgentBuilder::macro('track', function (Model $model) {
+        $this->trackedModel = $model;
+        return $this; // Return $this for method chaining
+    });
+}
+```
+
+### Using Your Macro
+
+```php
+use App\Models\Unit;
+use Vizra\VizraADK\Facades\Agent;
+
+// Step 1: Use the macro when registering the agent
+Agent::build(CustomerSupportAgent::class)
+    ->track(Unit::find(12))
+    ->register();
+
+// Step 2: Run the agent using the executor API
+$response = CustomerSupportAgent::run('User input')
+    ->forUser($user)
+    ->go();
+```
+
+## Real-World Examples
+
+### Analytics Tracking
+
+Track which models are using AI features:
+
+```php
+use Vizra\VizraADK\Services\AgentBuilder;
+use Illuminate\Database\Eloquent\Model;
+
+AgentBuilder::macro('track', function (Model $model) {
+    $this->trackedModel = $model;
+    $this->trackedModelType = get_class($model);
+    $this->trackedModelId = $model->getKey();
+    return $this;
+});
+
+// Usage
+Agent::build(MyAgent::class)
+    ->track(Unit::find(12))
+    ->register();
+
+// Then run the agent
+MyAgent::run('User input')
+    ->forUser($user)
+    ->go();
+```
+
+### Conditional Execution
+
+Add conditional logic to your builder:
+
+```php
+AgentBuilder::macro('whenCondition', function ($condition, callable $callback) {
+    if ($condition) {
+        $callback($this);
+    }
+    return $this;
+});
+
+// Usage
+$agentName = Agent::define('conditional-agent')
+    ->whenCondition($user->isPremium(), function ($builder) {
+        $builder->model('gpt-4o');
+    })
+    ->whenCondition(!$user->isPremium(), function ($builder) {
+        $builder->model('gpt-4o-mini');
+    })
+    ->register();
+
+// Run the defined agent
+Agent::named($agentName)->run('User input')->go();
+```
+
+### Metadata Tagging
+
+Add metadata for logging or debugging:
+
+```php
+AgentBuilder::macro('withTags', function (array $tags) {
+    $this->tags = $tags;
+    return $this;
+});
+
+AgentBuilder::macro('withPriority', function (string $priority) {
+    $this->priority = $priority;
+    return $this;
+});
+
+// Usage
+$agentName = Agent::define('support-agent')
+    ->withTags(['customer-facing', 'urgent'])
+    ->withPriority('high')
+    ->register();
+
+// Run the agent
+Agent::named($agentName)->run('User input')->go();
+```
+
+### Cost Tracking
+
+Track estimated costs for budget monitoring:
+
+```php
+AgentBuilder::macro('trackCost', function (string $costCenter) {
+    $this->costCenter = $costCenter;
+    $this->trackTokenUsage = true;
+    return $this;
+});
+
+// Usage
+Agent::build(AnalyticsAgent::class)
+    ->trackCost('DEPT-001')
+    ->register();
+
+// Run the agent
+AnalyticsAgent::run('User input')->go();
+```
+
+## Using Mixins
+
+Mixins allow you to add multiple macros at once:
+
+```php
+use Vizra\VizraADK\Services\AgentBuilder;
+
+class AnalyticsMixin
+{
+    public function track()
+    {
+        return function (Model $model) {
+            $this->trackedModel = $model;
+            return $this;
+        };
+    }
+
+    public function recordActivity()
+    {
+        return function ($activity) {
+            $this->activityLog[] = $activity;
+            return $this;
+        };
+    }
+
+    public function getActivityLog()
+    {
+        return function () {
+            return $this->activityLog ?? [];
+        };
+    }
+}
+
+// Register the mixin in your service provider
+public function boot(): void
+{
+    AgentBuilder::mixin(new AnalyticsMixin());
+}
+
+// Use the mixed-in methods
+$agentName = Agent::define('analytics-agent')
+    ->track($unit)
+    ->recordActivity('agent_created')
+    ->recordActivity('agent_configured')
+    ->register();
+
+// Run the agent
+Agent::named($agentName)->run('User input')->go();
+```
+
+## Advanced Patterns
+
+### Integration with Events
+
+Combine macros with Laravel events:
+
+```php
+AgentBuilder::macro('trackWithEvent', function (Model $model) {
+    $this->trackedModel = $model;
+    
+    // Fire an event when the agent is used
+    event(new AgentTracked($model, $this));
+    
+    return $this;
+});
+```
+
+### Dynamic Configuration
+
+Load configuration dynamically:
+
+```php
+AgentBuilder::macro('configureFor', function (Model $model) {
+    // Load model-specific configuration
+    $config = $model->agentConfiguration ?? [];
+    
+    if (isset($config['model'])) {
+        $this->model($config['model']);
+    }
+    
+    if (isset($config['instructions'])) {
+        $this->instructions($config['instructions']);
+    }
+    
+    return $this;
+});
+
+// Usage
+Agent::build(MyAgent::class)
+    ->configureFor($tenant)
+    ->register();
+
+// Run the agent
+MyAgent::run('User input')->go();
+```
+
+### Workflow Macros
+
+Add custom workflow types:
+
+```php
+use Vizra\VizraADK\Facades\Workflow;
+use Vizra\VizraADK\Services\WorkflowManager;
+
+WorkflowManager::macro('retryable', function (string $agentClass, int $maxRetries = 3) {
+    $retries = $maxRetries;
+    return Workflow::loop($agentClass)
+        ->until(function ($result) use (&$retries) {
+            return $result->success || $retries-- <= 0;
+        });
+});
+
+// Usage
+$result = Workflow::retryable(UnreliableAgent::class, 5)->go();
+```
+
+## Best Practices
+
+1. **Always return `$this`** - This maintains the fluent interface
+2. **Register in service providers** - Keep macro registration in `AppServiceProvider::boot()`
+3. **Use descriptive names** - Make macro purpose clear from the name
+4. **Document your macros** - Help other developers understand what they do
+5. **Consider scope** - Macros are global, so namespace them if needed
+6. **Test your macros** - Write tests to ensure they work as expected
+
+## Testing Macros
+
+```php
+use Vizra\VizraADK\Services\AgentBuilder;
+use Vizra\VizraADK\Facades\Agent;
+
+it('can track models with macro', function () {
+    AgentBuilder::macro('track', function (Model $model) {
+        $this->trackedModel = $model;
+        return $this;
+    });
+
+    $model = Unit::factory()->create();
+    $builder = Agent::define('test-agent')->track($model);
+
+    expect($builder->trackedModel)->toBe($model);
+});
+```
+
+## Learn More
+
+- [Laravel Macros Documentation](https://laravel.com/docs/11.x/helpers#method-macro)
+- [Laravel Macros and Mixins Article](https://coderden.dev/posts/laravel-macros-and-mixin)
+- [Vizra ADK Documentation](https://vizra.ai/docs)

--- a/examples/AnalyticsTrackingExample.php
+++ b/examples/AnalyticsTrackingExample.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Vizra\VizraADK\Examples;
+
+use Illuminate\Database\Eloquent\Model;
+use Vizra\VizraADK\Services\AgentBuilder;
+use Vizra\VizraADK\Facades\Agent;
+
+/**
+ * Example: Analytics Tracking with Macros
+ * 
+ * This example demonstrates how to use Laravel macros to add
+ * model tracking functionality to Vizra ADK agents for analytics purposes.
+ * 
+ * Usage:
+ * 1. Register the macro in your AppServiceProvider::boot() method
+ * 2. Use the track() method when building agents
+ * 3. Access the tracked model data in your analytics system
+ */
+class AnalyticsTrackingExample
+{
+    /**
+     * Register the analytics tracking macros
+     * 
+     * Call this in your AppServiceProvider::boot() method
+     */
+    public static function registerMacros(): void
+    {
+        /**
+         * Track a model for analytics purposes
+         * 
+         * This macro stores a reference to a model instance, allowing you
+         * to associate token usage, execution time, and other metrics
+         * with specific models in your application.
+         * 
+         * @param Model $model The model to track (e.g., Unit, Tenant, User)
+         * @return AgentBuilder Returns $this for method chaining
+         */
+        AgentBuilder::macro('track', function (Model $model) {
+            // Store the model for later retrieval
+            $this->trackedModel = $model;
+            $this->trackedModelType = get_class($model);
+            $this->trackedModelId = $model->getKey();
+            
+            return $this;
+        });
+
+        /**
+         * Track with additional context
+         * 
+         * @param Model $model The model to track
+         * @param array $context Additional context data
+         * @return AgentBuilder Returns $this for method chaining
+         */
+        AgentBuilder::macro('trackWithContext', function (Model $model, array $context = []) {
+            $this->trackedModel = $model;
+            $this->trackedModelType = get_class($model);
+            $this->trackedModelId = $model->getKey();
+            $this->trackingContext = $context;
+            
+            return $this;
+        });
+
+        /**
+         * Set a cost center for budget tracking
+         * 
+         * @param string $costCenter The cost center identifier
+         * @return AgentBuilder Returns $this for method chaining
+         */
+        AgentBuilder::macro('costCenter', function (string $costCenter) {
+            $this->costCenter = $costCenter;
+            
+            return $this;
+        });
+    }
+
+    /**
+     * Example 1: Basic model tracking
+     */
+    public static function basicTracking()
+    {
+        // Assuming you have a Unit model
+        $unit = self::getExampleUnit();
+
+        // First, register the macro to enable tracking
+        AgentBuilder::macro('track', function ($model) {
+            $this->trackedModel = $model;
+            return $this;
+        });
+
+        // Register the agent with tracking
+        Agent::build(\Vizra\VizraADK\Examples\agents\PersonalShoppingAssistantAgent::class)
+            ->track($unit)
+            ->register();
+
+        // Now run the agent (uses the AgentExecutor API)
+        $response = \Vizra\VizraADK\Examples\agents\PersonalShoppingAssistantAgent::run('Help me find a gift')
+            ->forUser(auth()->user())
+            ->go();
+
+        // The tracked model can be accessed later for analytics
+        // (You would typically do this in an event listener or middleware)
+        return $response;
+    }
+
+    /**
+     * Example 2: Track with additional context
+     */
+    public static function trackingWithContext()
+    {
+        $unit = self::getExampleUnit();
+
+        // Register the macro if not already registered
+        AgentBuilder::macro('trackWithContext', function ($model, $context) {
+            $this->trackedModel = $model;
+            $this->trackingContext = $context;
+            return $this;
+        });
+
+        // Register the agent with context tracking
+        Agent::build(\Vizra\VizraADK\Examples\agents\PersonalShoppingAssistantAgent::class)
+            ->trackWithContext($unit, [
+                'department' => 'Sales',
+                'campaign' => 'Q4-2024',
+                'feature' => 'shopping_assistant',
+            ])
+            ->register();
+
+        // Run the agent
+        $response = \Vizra\VizraADK\Examples\agents\PersonalShoppingAssistantAgent::run('Show me popular products')
+            ->forUser(auth()->user())
+            ->go();
+
+        return $response;
+    }
+
+    /**
+     * Example 3: Cost center tracking for budget monitoring
+     */
+    public static function costCenterTracking()
+    {
+        $unit = self::getExampleUnit();
+
+        // Register macros for tracking
+        AgentBuilder::macro('track', function ($model) {
+            $this->trackedModel = $model;
+            return $this;
+        });
+
+        AgentBuilder::macro('costCenter', function ($costCenter) {
+            $this->costCenter = $costCenter;
+            return $this;
+        });
+
+        // Register the agent with cost center tracking
+        Agent::build(\Vizra\VizraADK\Examples\agents\PersonalShoppingAssistantAgent::class)
+            ->track($unit)
+            ->costCenter('DEPT-SALES-001')
+            ->register();
+
+        // Run the agent
+        $response = \Vizra\VizraADK\Examples\agents\PersonalShoppingAssistantAgent::run('What can you help me with?')
+            ->forUser(auth()->user())
+            ->go();
+
+        return $response;
+    }
+
+    /**
+     * Example 4: Using tracked data in an event listener
+     */
+    public static function exampleEventListener()
+    {
+        // In a real application, you would register this listener in EventServiceProvider
+        // This shows how you might access the tracked data
+
+        return <<<'PHP'
+<?php
+
+namespace App\Listeners;
+
+use Vizra\VizraADK\Events\AgentExecutionFinished;
+use App\Models\AgentUsageLog;
+
+class TrackAgentUsage
+{
+    public function handle(AgentExecutionFinished $event): void
+    {
+        $context = $event->context;
+        
+        // Access the tracked model from the builder
+        // Note: You would need to pass this through the context
+        if (isset($context->builder->trackedModel)) {
+            AgentUsageLog::create([
+                'trackable_type' => $context->builder->trackedModelType,
+                'trackable_id' => $context->builder->trackedModelId,
+                'agent_name' => $context->agentName,
+                'user_id' => $context->user?->id,
+                'cost_center' => $context->builder->costCenter ?? null,
+                'input_tokens' => $event->inputTokens,
+                'output_tokens' => $event->outputTokens,
+                'total_tokens' => $event->totalTokens,
+                'execution_time_ms' => $event->executionTime,
+                'context' => $context->builder->trackingContext ?? null,
+            ]);
+        }
+    }
+}
+PHP;
+    }
+
+    /**
+     * Example migration for tracking table
+     */
+    public static function exampleMigration()
+    {
+        return <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_usage_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('trackable_type');
+            $table->unsignedBigInteger('trackable_id');
+            $table->string('agent_name');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('cost_center')->nullable();
+            $table->integer('input_tokens')->default(0);
+            $table->integer('output_tokens')->default(0);
+            $table->integer('total_tokens')->default(0);
+            $table->integer('execution_time_ms')->default(0);
+            $table->json('context')->nullable();
+            $table->timestamps();
+
+            $table->index(['trackable_type', 'trackable_id']);
+            $table->index('cost_center');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_usage_logs');
+    }
+};
+PHP;
+    }
+
+    /**
+     * Get an example unit model (for demonstration purposes)
+     */
+    private static function getExampleUnit()
+    {
+        // In a real application, you would fetch this from your database
+        // For this example, we'll create a mock object
+        return new class extends Model {
+            protected $table = 'units';
+            protected $fillable = ['id', 'name'];
+            
+            public function __construct()
+            {
+                parent::__construct(['id' => 12, 'name' => 'Example Unit']);
+            }
+
+            public function getKey()
+            {
+                return 12;
+            }
+        };
+    }
+}

--- a/src/Services/AgentManager.php
+++ b/src/Services/AgentManager.php
@@ -4,6 +4,7 @@ namespace Vizra\VizraADK\Services;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Traits\Macroable;
 use Vizra\VizraADK\Agents\BaseAgent;
 use Vizra\VizraADK\Agents\BaseLlmAgent;
 use Vizra\VizraADK\Events\AgentExecutionFinished; // For AgentResponseGenerated
@@ -11,8 +12,34 @@ use Vizra\VizraADK\Events\AgentExecutionStarting; // For AgentResponseGenerated
 use Vizra\VizraADK\Events\AgentResponseGenerated;
 use Vizra\VizraADK\Exceptions\AgentConfigurationException;
 
+/**
+ * AgentManager - Central management service for Vizra ADK agents
+ *
+ * This class supports Laravel macros, allowing you to extend its functionality
+ * with custom methods at runtime. This is useful for adding analytics tracking,
+ * custom integrations, or any other behavior without modifying the core package.
+ *
+ * Example usage:
+ * ```php
+ * use Vizra\VizraADK\Facades\Agent;
+ * use Illuminate\Database\Eloquent\Model;
+ *
+ * // Register a macro to track agent usage with a model
+ * Agent::macro('track', function (Model $model) {
+ *     // Store the model for tracking token usage or analytics
+ *     $this->builder->setTrackedModel($model);
+ *     return $this;
+ * });
+ *
+ * // Use the macro
+ * Agent::build(MyAgent::class)
+ *     ->track(Unit::find(12))
+ *     ->go();
+ * ```
+ */
 class AgentManager
 {
+    use Macroable;
     protected Application $app;
 
     protected AgentRegistry $registry;

--- a/src/Services/WorkflowManager.php
+++ b/src/Services/WorkflowManager.php
@@ -2,6 +2,7 @@
 
 namespace Vizra\VizraADK\Services;
 
+use Illuminate\Support\Traits\Macroable;
 use Vizra\VizraADK\Agents\ConditionalWorkflow;
 use Vizra\VizraADK\Agents\LoopWorkflow;
 use Vizra\VizraADK\Agents\ParallelWorkflow;
@@ -12,9 +13,24 @@ use Vizra\VizraADK\Agents\SequentialWorkflow;
  *
  * Provides factory methods for creating different types of workflow agents.
  * This class powers the Workflow facade and enables fluent workflow creation.
+ *
+ * This class supports Laravel macros, allowing you to extend workflow functionality
+ * with custom workflow types or configuration methods.
+ *
+ * Example usage:
+ * ```php
+ * use Vizra\VizraADK\Facades\Workflow;
+ *
+ * // Register a custom workflow type macro
+ * Workflow::macro('retryable', function (string $agentClass, int $maxRetries = 3) {
+ *     return Workflow::loop($agentClass)
+ *         ->until(fn($result) => $result->success || $maxRetries-- <= 0);
+ * });
+ * ```
  */
 class WorkflowManager
 {
+    use Macroable;
     /**
      * Create a sequential workflow
      *

--- a/tests/Feature/MacroSupportTest.php
+++ b/tests/Feature/MacroSupportTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Vizra\VizraADK\Facades\Agent;
+use Vizra\VizraADK\Facades\Workflow;
+use Vizra\VizraADK\Services\AgentBuilder;
+use Vizra\VizraADK\Services\AgentManager;
+use Vizra\VizraADK\Services\WorkflowManager;
+
+// Test that AgentManager supports macros
+it('can register and use macros on AgentManager', function () {
+    // Register a macro
+    AgentManager::macro('testMethod', function () {
+        return 'macro works';
+    });
+
+    // Access through the facade
+    $result = Agent::testMethod();
+
+    expect($result)->toBe('macro works');
+});
+
+// Test that AgentBuilder supports macros
+it('can register and use macros on AgentBuilder', function () {
+    // Register a macro that returns $this for chaining
+    AgentBuilder::macro('customConfig', function ($value) {
+        $this->customValue = $value;
+        return $this;
+    });
+
+    // Use the macro through agent building
+    $builder = Agent::define('test-agent')
+        ->instructions('Test instructions')
+        ->customConfig('test-value');
+
+    expect($builder)->toBeInstanceOf(AgentBuilder::class);
+});
+
+// Test that WorkflowManager supports macros
+it('can register and use macros on WorkflowManager', function () {
+    // Register a macro
+    WorkflowManager::macro('customWorkflow', function () {
+        return 'custom workflow';
+    });
+
+    // Access through the facade
+    $result = Workflow::customWorkflow();
+
+    expect($result)->toBe('custom workflow');
+});
+
+// Test the track() macro use case for analytics
+it('can register a track macro for model association', function () {
+    // Create a mock model
+    $model = Mockery::mock(Model::class);
+    $model->shouldReceive('getKey')->andReturn(12);
+
+    // Register the track macro on AgentBuilder
+    AgentBuilder::macro('track', function (Model $model) {
+        $this->trackedModel = $model;
+        return $this;
+    });
+
+    // Use the macro
+    $builder = Agent::define('analytics-agent')
+        ->instructions('Test analytics')
+        ->track($model);
+
+    expect($builder)->toBeInstanceOf(AgentBuilder::class)
+        ->and($builder->trackedModel)->toBe($model);
+});
+
+// Test that macros can access protected properties
+it('allows macros to access and modify builder state', function () {
+    // Register a macro that accesses builder properties
+    AgentBuilder::macro('withMetadata', function (array $metadata) {
+        if (!property_exists($this, 'metadata')) {
+            $this->metadata = [];
+        }
+        $this->metadata = array_merge($this->metadata ?? [], $metadata);
+        return $this;
+    });
+
+    // Use the macro
+    $builder = Agent::define('meta-agent')
+        ->withMetadata(['source' => 'api', 'version' => '1.0']);
+
+    expect($builder->metadata)->toBe(['source' => 'api', 'version' => '1.0']);
+});
+
+// Test that multiple macros can be chained
+it('allows chaining multiple macros together', function () {
+    // Register multiple macros
+    AgentBuilder::macro('withTags', function (array $tags) {
+        $this->tags = $tags;
+        return $this;
+    });
+
+    AgentBuilder::macro('withPriority', function (string $priority) {
+        $this->priority = $priority;
+        return $this;
+    });
+
+    // Chain them together
+    $builder = Agent::define('tagged-agent')
+        ->withTags(['important', 'customer-facing'])
+        ->withPriority('high');
+
+    expect($builder->tags)->toBe(['important', 'customer-facing'])
+        ->and($builder->priority)->toBe('high');
+});
+
+// Test that macros persist across multiple instances
+it('makes macros available to all instances', function () {
+    // Register a macro
+    AgentBuilder::macro('enableDebug', function () {
+        $this->debugMode = true;
+        return $this;
+    });
+
+    // Create multiple instances and use the macro
+    $builder1 = Agent::define('agent-1')->enableDebug();
+    $builder2 = Agent::define('agent-2')->enableDebug();
+
+    expect($builder1->debugMode)->toBeTrue()
+        ->and($builder2->debugMode)->toBeTrue();
+});
+
+// Test mixin functionality
+it('can use mixins to add multiple macros at once', function () {
+    // Create a mixin class
+    $mixin = new class {
+        public function logActivity()
+        {
+            return function ($activity) {
+                $this->activityLog[] = $activity;
+                return $this;
+            };
+        }
+
+        public function getActivityLog()
+        {
+            return function () {
+                return $this->activityLog ?? [];
+            };
+        }
+    };
+
+    // Register the mixin
+    AgentBuilder::mixin($mixin);
+
+    // Use the mixed-in methods
+    $builder = Agent::define('logging-agent')
+        ->logActivity('created')
+        ->logActivity('configured');
+
+    expect($builder->getActivityLog())->toBe(['created', 'configured']);
+});
+
+// Test that macros work with the facade
+it('can call macros through the Agent facade', function () {
+    // Register a macro on AgentManager
+    AgentManager::macro('version', function () {
+        return '1.0.0';
+    });
+
+    // Call through the facade
+    $version = Agent::version();
+
+    expect($version)->toBe('1.0.0');
+});
+
+// Test conditional macro behavior
+it('can create conditional macros', function () {
+    // Register a conditional macro
+    AgentBuilder::macro('whenCondition', function ($condition, callable $callback) {
+        if ($condition) {
+            $callback($this);
+        }
+        return $this;
+    });
+
+    $model = Mockery::mock(Model::class);
+
+    // Test with condition true
+    $executedTrue = false;
+    $builder1 = Agent::define('agent-1')
+        ->whenCondition(true, function ($builder) use (&$executedTrue, $model) {
+            $builder->trackedModelTrue = $model;
+            $executedTrue = true;
+        });
+
+    expect($executedTrue)->toBeTrue()
+        ->and($builder1->trackedModelTrue)->toBe($model);
+
+    // Test with condition false
+    $executedFalse = false;
+    $builder2 = Agent::define('agent-2')
+        ->whenCondition(false, function ($builder) use (&$executedFalse) {
+            $builder->trackedModelFalse = 'should not execute';
+            $executedFalse = true;
+        });
+
+    expect($executedFalse)->toBeFalse()
+        ->and(property_exists($builder2, 'trackedModelFalse'))->toBeFalse();
+});


### PR DESCRIPTION
* Add Laravel macros and mixins support to Vizra ADK

* Fix syntax error in AnalyticsTrackingExample

* Add macros section to README

* Fix incorrect API usage in examples and documentation

- Replace non-existent WeatherAgent with PersonalShoppingAssistantAgent in examples
- Fix incorrect chaining of forUser/go on AgentBuilder (should use AgentExecutor)
- Update README, MACROS.md, and AgentBuilder docblock with correct two-step pattern:
  1. Register agent with macros using Agent::build()->register()
  2. Run agent using MyAgent::run()->forUser()->go()
- Add macro registration examples inline where appropriate

* Refactor AgentBuilder reset logic