### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,89 +1,89 @@
 {
-  "name": "vizra/vizra-adk",
-  "version": "0.0.46",
-  "description": "Vizra Agent Development Kit - A comprehensive Laravel package for building intelligent AI agents.",
-  "support": {
-    "issues": "https://github.com/vizra-ai/vizra-adk/issues",
-    "source": "https://github.com/vizra-ai/vizra-adk",
-    "docs": "https://vizra.ai/docs",
-    "chat": "https://discord.gg/CRRzmvS5MK"
-  },
-  "keywords": [
-    "laravel",
-    "ai",
-    "agents",
-    "llm",
-    "openai",
-    "anthropic",
-    "gemini",
-    "gpt",
-    "claude",
-    "ai-agents",
-    "ai-tools",
-    "agent-framework",
-    "workflow",
-    "rag",
-    "vector-memory",
-    "mcp",
-    "model-context-protocol",
-    "prism-php",
-    "embedding",
-    "ai-development-kit",
-    "intelligent-agents",
-    "conversational-ai",
-    "ai-workflows",
-    "memory-persistence",
-    "meilisearch"
-  ],
-  "type": "laravel-package",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Aaron Lumsden",
-      "email": "aaronlumsden@me.com"
+    "name": "vizra/vizra-adk",
+    "version": "0.0.46",
+    "description": "Vizra Agent Development Kit - A comprehensive Laravel package for building intelligent AI agents.",
+    "support": {
+        "issues": "https://github.com/vizra-ai/vizra-adk/issues",
+        "source": "https://github.com/vizra-ai/vizra-adk",
+        "docs": "https://vizra.ai/docs",
+        "chat": "https://discord.gg/CRRzmvS5MK"
+    },
+    "keywords": [
+        "laravel",
+        "ai",
+        "agents",
+        "llm",
+        "openai",
+        "anthropic",
+        "gemini",
+        "gpt",
+        "claude",
+        "ai-agents",
+        "ai-tools",
+        "agent-framework",
+        "workflow",
+        "rag",
+        "vector-memory",
+        "mcp",
+        "model-context-protocol",
+        "prism-php",
+        "embedding",
+        "ai-development-kit",
+        "intelligent-agents",
+        "conversational-ai",
+        "ai-workflows",
+        "memory-persistence",
+        "meilisearch"
+    ],
+    "type": "laravel-package",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Aaron Lumsden",
+            "email": "aaronlumsden@me.com"
+        }
+    ],
+    "require": {
+        "php": "^8.2",
+        "laravel/framework": "^11.0|^12.0|^13.0",
+        "prism-php/prism": "^0.99.0",
+        "league/csv": "^9.23",
+        "livewire/livewire": "^3.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^9.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Vizra\\VizraADK\\": "src/",
+            "Vizra\\VizraADK\\Examples\\": "examples/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Vizra\\VizraADK\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Vizra\\VizraADK\\Providers\\AgentServiceProvider"
+            ],
+            "aliases": {
+                "Agent": "Vizra\\VizraADK\\Facades\\Agent",
+                "Workflow": "Vizra\\VizraADK\\Facades\\Workflow"
+            }
+        }
+    },
+    "scripts": {
+        "test": "pest",
+        "test-coverage": "pest --coverage"
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
-  ],
-  "require": {
-    "php": "^8.2",
-    "laravel/framework": "^11.0|^12.0",
-    "prism-php/prism": "^0.99.0",
-    "league/csv": "^9.23",
-    "livewire/livewire": "^3.0"
-  },
-  "require-dev": {
-    "orchestra/testbench": "^9.0",
-    "pestphp/pest": "^3.0",
-    "pestphp/pest-plugin-laravel": "^3.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Vizra\\VizraADK\\": "src/",
-      "Vizra\\VizraADK\\Examples\\": "examples/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Vizra\\VizraADK\\Tests\\": "tests/"
-    }
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Vizra\\VizraADK\\Providers\\AgentServiceProvider"
-      ],
-      "aliases": {
-        "Agent": "Vizra\\VizraADK\\Facades\\Agent",
-        "Workflow": "Vizra\\VizraADK\\Facades\\Workflow"
-      }
-    }
-  },
-  "scripts": {
-    "test": "pest",
-    "test-coverage": "pest --coverage"
-  },
-  "config": {
-    "allow-plugins": {
-      "pestphp/pest-plugin": true
-    }
-  }
 }


### PR DESCRIPTION
Widens `laravel/framework` constraint from `^11.0|^12.0` to `^11.0|^12.0|^13.0` to support Laravel 13 applications.

No breaking changes - purely a constraint relaxation.